### PR TITLE
fixed scripts for sentencepiece

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ cd ../
   #sentencepiece style
   python3 ../ot_run.py --source_file spmoutput/source.file --target_file spmoutput/target.file \
             --token_candidate_file spm.vocab \
-            --vocab_file spmoutput/vocab --max_number 10000 --interval 1000  --loop_in_ot 500 --tokenizer sentencepiece --size_file spmoutput/size 
+            --max_number 10000 --interval 1000  --loop_in_ot 500 --tokenizer sentencepiece --size_file spmoutput/size 
 
   #For non-seq2seq tasks with one source file, you can use the following commands:
   #subword-nmt style
@@ -120,10 +120,9 @@ cd ../
             --vocab_file bpeoutput/vocab --max_number 10000 --interval 1000  --loop_in_ot 500 --tokenizer subword-nmt --size_file bpeoutput/size 
     
   #sentencepiece style
-  BPE_CODE=spm.vocab
   python3 ../ot_run.py --source_file spmoutput/source.file \
             --token_candidate_file spm.vocab  \
-            --vocab_file spmoutput/vocab --max_number 10000 --interval 1000  --loop_in_ot 500 --tokenizer sentencepiece --size_file spmoutput/size 
+            --max_number 10000 --interval 1000  --loop_in_ot 500 --tokenizer sentencepiece --size_file spmoutput/size 
 
   ```
 * The third step is to use the generated vocabulary to segment your texts:

--- a/get_tokens.py
+++ b/get_tokens.py
@@ -16,31 +16,31 @@ def read_tokens(path, tokens={}, max_number_line=1e7, tokenizer='subword-nmt'): 
        tokens: return all tokens and their frequencies
     """
     with open(path, 'r') as sr:
-         lines = sr.readlines()
-         total_lines = min(len(lines), max_number_line)
-         total_lines = int(total_lines)
-         for i in range(total_lines):
-             line = lines[i]
-             items = line.split()
-             for item in items:
-                 if tokenizer == 'subword-nmt':
-                     special_tokens = "@@"
-                     if not item.endswith(special_tokens):
-                            if item+"</w>" not in tokens:
-                                 tokens[item+"</w>"] = 1
-                            else:
-                                 tokens[item+"</w>"] += 1
-                     else:
-                          if item not in tokens:
-                               tokens[item] = 1
-                          else:
-                               tokens[item] += 1
-                 elif tokenizer == 'sentencepiece':
+        lines = sr.readlines()
+        total_lines = min(len(lines), max_number_line)
+        total_lines = int(total_lines)
+        for i in range(total_lines):
+            line = lines[i]
+            items = line.split()
+            for item in items:
+                if tokenizer == 'subword-nmt':
+                    special_tokens = "@@"
+                    if not item.endswith(special_tokens):
+                        if item+"</w>" not in tokens:
+                            tokens[item+"</w>"] = 1
+                        else:
+                            tokens[item+"</w>"] += 1
+                    else:
+                        if item not in tokens:
+                            tokens[item] = 1
+                        else:
+                            tokens[item] += 1
+                elif tokenizer == 'sentencepiece':
                     if item not in tokens:
                         tokens[item] =1 
                     else:
                         tokens[item] += 1
-                 else:
+                else:
                     print("Errors: we only support subword-nmt and sentencepiece!")
     return tokens
 
@@ -57,20 +57,29 @@ def read_merge_code_frequency(path, tokens, min_number=1, tokenizer='subword-nmt
     """
     print("reading candidate tokens")
     with open(path, 'r') as sr:
-         lines = sr.readlines()
-         merge_dict = OrderedDict()
-         # for bpe codes, the first line shows code version
-         if tokenizer == 'subword-nmt':
-             lines = lines[1:] # the first line is version number
-         for line in tqdm(lines):
-             merge = line.strip()
-             items = merge.split(" ")
-             token = "".join(items)
-             merge_dict[merge] = min_number
-             for split_token in tokens:
-                 #merge_dict[merge] = min_number
-                 if token in split_token:
-                     merge_dict[merge] += tokens[split_token]
+        lines = sr.readlines()
+        merge_dict = OrderedDict()
+        # for bpe codes, the first line shows code version
+        if tokenizer == 'subword-nmt':
+            lines = lines[1:] # the first line is version number
+            for line in tqdm(lines):
+                merge = line.strip()
+                items = merge.split(" ")
+                token = "".join(items)
+                merge_dict[merge] = min_number
+                for split_token in tokens:
+                    #merge_dict[merge] = min_number
+                    if token in split_token:
+                        merge_dict[merge] += tokens[split_token]
+        if tokenizer == 'sentencepiece':
+            for line in tqdm(lines):
+                merge = line.strip()
+                token = merge.split("\t")[0]
+                merge_dict[token] = min_number
+                for split_token in tokens:
+                    #merge_dict[merge] = min_number
+                    if token in split_token:
+                        merge_dict[token] += tokens[split_token]
 
     return merge_dict
 

--- a/ot_run.py
+++ b/ot_run.py
@@ -194,7 +194,7 @@ if __name__ == "__main__":
     parser.add_argument('--token_candidate_file', default=None,
                         help='path to token candidates. In this implementation, we take BPE-generated code segmentation as token candidates.')
     parser.add_argument('--vocab_file', default=None,
-                       help='path to the file storing the generated tokens.')
+                       help='path to the file storing the generated tokens. unnecessary for sentencepiece.')
     parser.add_argument('--max_number', default=10000, type=int,
                        help='the maximum size of the generated vocabulary')
     parser.add_argument('--interval', default=1000, type=int,
@@ -222,8 +222,11 @@ if __name__ == "__main__":
     oldtokens = get_tokens.get_tokens(source_file, target_file, token_candidate_file, tokenizer=args.tokenizer) # get token candidates and their frequencies
     chars = get_chars.get_chars(source_file, target_file, tokenizer=args.tokenizer) # get chars and their frequencies
     optimal_size = run_ot(oldtokens, chars, max_number,interval, num_iter_max) # generate the best ot size
-    Gs = run_ot_write(oldtokens, chars, optimal_size, num_iter_max) # generate the optimal matrix based on the ot size
-    write_vocab(oldtokens, Gs, chars, vocab_file, threshold) #generate the vocabulary based on the optimal matrix
+    
+    if tekenizer == 'subword-nmt':
+        Gs = run_ot_write(oldtokens, chars, optimal_size, num_iter_max) # generate the optimal matrix based on the ot size
+        write_vocab(oldtokens, Gs, chars, vocab_file, threshold) #generate the vocabulary based on the optimal matrix
+        
     with open(size_file, 'w') as sw:
          sw.write(str(optimal_size)+"\n")
     #return optimal_size


### PR DESCRIPTION
1. Fixed mistakes in `get_tokens.py` when reading candidate tokens from vocab files generated by sentencepiece.
2. When using sentencepiece tokenizer, the vocabulary `vocab_file` generated by the `run_ot.py` script won't be used again in steps later on and therefore is redundant. `run_ot.py` was fixed to generate only `size_file` for sentencepiece tokenizer.